### PR TITLE
Update shank version and regenerate IDLs

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -25,7 +25,7 @@
   "author": "Metaplex Maintainers <contact@metaplex.com>",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@metaplex-foundation/umi": "^0.8.2"
+    "@metaplex-foundation/umi": ">= 0.8.2 < 1"
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",

--- a/idls/mpl_system_extras.json
+++ b/idls/mpl_system_extras.json
@@ -9,19 +9,25 @@
           "name": "payer",
           "isMut": true,
           "isSigner": true,
-          "desc": "The account paying for the storage"
+          "docs": [
+            "The account paying for the storage"
+          ]
         },
         {
           "name": "newAccount",
           "isMut": true,
           "isSigner": true,
-          "desc": "The account being created"
+          "docs": [
+            "The account being created"
+          ]
         },
         {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false,
-          "desc": "System program"
+          "docs": [
+            "System program"
+          ]
         }
       ],
       "args": [
@@ -46,19 +52,25 @@
           "name": "source",
           "isMut": true,
           "isSigner": true,
-          "desc": "The source account sending all its lamports"
+          "docs": [
+            "The source account sending all its lamports"
+          ]
         },
         {
           "name": "destination",
           "isMut": true,
           "isSigner": false,
-          "desc": "The destination account receiving the lamports"
+          "docs": [
+            "The destination account receiving the lamports"
+          ]
         },
         {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false,
-          "desc": "System program"
+          "docs": [
+            "System program"
+          ]
         }
       ],
       "args": [],
@@ -83,7 +95,7 @@
   "metadata": {
     "origin": "shank",
     "address": "SysExL2WDyJi9aRZrXorrjHJut3JwHQ7R9bTyctbNNG",
-    "binaryVersion": "0.0.12",
-    "libVersion": "0.0.12"
+    "binaryVersion": "0.3.0",
+    "libVersion": "0.3.0"
   }
 }

--- a/idls/mpl_token_extras.json
+++ b/idls/mpl_token_extras.json
@@ -9,49 +9,65 @@
           "name": "payer",
           "isMut": true,
           "isSigner": true,
-          "desc": "The account paying for the token account creation if needed"
+          "docs": [
+            "The account paying for the token account creation if needed"
+          ]
         },
         {
           "name": "token",
           "isMut": false,
           "isSigner": false,
-          "desc": "The token account that may or may not exist"
+          "docs": [
+            "The token account that may or may not exist"
+          ]
         },
         {
           "name": "mint",
           "isMut": false,
           "isSigner": false,
-          "desc": "The mint account of the provided token account"
+          "docs": [
+            "The mint account of the provided token account"
+          ]
         },
         {
           "name": "owner",
           "isMut": false,
           "isSigner": false,
-          "desc": "The owner of the provided token account"
+          "docs": [
+            "The owner of the provided token account"
+          ]
         },
         {
           "name": "ata",
           "isMut": true,
           "isSigner": false,
-          "desc": "The associated token account which may be the same as the token account"
+          "docs": [
+            "The associated token account which may be the same as the token account"
+          ]
         },
         {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false,
-          "desc": "System program"
+          "docs": [
+            "System program"
+          ]
         },
         {
           "name": "tokenProgram",
           "isMut": false,
           "isSigner": false,
-          "desc": "Token program"
+          "docs": [
+            "Token program"
+          ]
         },
         {
           "name": "ataProgram",
           "isMut": false,
           "isSigner": false,
-          "desc": "Associated Token program"
+          "docs": [
+            "Associated Token program"
+          ]
         }
       ],
       "args": [],
@@ -106,7 +122,7 @@
   "metadata": {
     "origin": "shank",
     "address": "TokExjvjJmhKaRBShsBAsbSvEWMA1AgUNK7ps4SAc2p",
-    "binaryVersion": "0.0.12",
-    "libVersion": "0.0.12"
+    "binaryVersion": "0.3.0",
+    "libVersion": "0.3.0"
   }
 }

--- a/programs/system-extras/Cargo.toml
+++ b/programs/system-extras/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 solana-program = "=1.14.13"
-shank = "0.0.12"
+shank = "0.3.0"
 borsh = "0.9.3"
 thiserror = "~1.0"
 num-derive = "0.3.3"

--- a/programs/token-extras/Cargo.toml
+++ b/programs/token-extras/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 solana-program = "=1.14.13"
-shank = "0.0.12"
+shank = "0.3.0"
 borsh = "0.9.3"
 thiserror = "~1.0"
 num-derive = "0.3.3"


### PR DESCRIPTION
* Updated to newer shank (from 0.0.12 to 0.3.0) to fix CI failure: https://github.com/metaplex-foundation/mpl-toolbox/actions/runs/7740620654/job/21106394075#step:6:72
* Add @MarkSackerberg's PR for Umi version range >= 0.8.2 < 1