### PR TITLE
feat(associated token pda search): add tokenProgramId param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 .amman
 .crates
 .bin
+.idea

--- a/clients/js/.gitignore
+++ b/clients/js/.gitignore
@@ -1,2 +1,3 @@
 .vercel
 docs
+.idea

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaplex-foundation/mpl-toolbox",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Auto-generated essential Solana and Metaplex programs",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/clients/js/src/generated/instructions/createAssociatedToken.ts
+++ b/clients/js/src/generated/instructions/createAssociatedToken.ts
@@ -70,10 +70,18 @@ export function createAssociatedToken(
   if (!resolvedAccounts.owner.value) {
     resolvedAccounts.owner.value = context.identity.publicKey;
   }
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
   if (!resolvedAccounts.ata.value) {
     resolvedAccounts.ata.value = findAssociatedTokenPda(context, {
       owner: expectPublicKey(resolvedAccounts.owner.value),
       mint: expectPublicKey(resolvedAccounts.mint.value),
+      tokenProgramId: expectPublicKey(resolvedAccounts.tokenProgram.value),
     });
   }
   if (!resolvedAccounts.systemProgram.value) {
@@ -82,13 +90,6 @@ export function createAssociatedToken(
       '11111111111111111111111111111111'
     );
     resolvedAccounts.systemProgram.isWritable = false;
-  }
-  if (!resolvedAccounts.tokenProgram.value) {
-    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
-      'splToken',
-      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-    );
-    resolvedAccounts.tokenProgram.isWritable = false;
   }
 
   // Accounts in order.

--- a/clients/js/src/generated/instructions/createTokenIfMissing.ts
+++ b/clients/js/src/generated/instructions/createTokenIfMissing.ts
@@ -115,10 +115,18 @@ export function createTokenIfMissing(
   if (!resolvedAccounts.owner.value) {
     resolvedAccounts.owner.value = context.identity.publicKey;
   }
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
   if (!resolvedAccounts.ata.value) {
     resolvedAccounts.ata.value = findAssociatedTokenPda(context, {
       owner: expectPublicKey(resolvedAccounts.owner.value),
       mint: expectPublicKey(resolvedAccounts.mint.value),
+      tokenProgramId: expectPublicKey(resolvedAccounts.tokenProgram.value),
     });
   }
   if (!resolvedAccounts.token.value) {
@@ -130,13 +138,6 @@ export function createTokenIfMissing(
       '11111111111111111111111111111111'
     );
     resolvedAccounts.systemProgram.isWritable = false;
-  }
-  if (!resolvedAccounts.tokenProgram.value) {
-    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
-      'splToken',
-      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-    );
-    resolvedAccounts.tokenProgram.isWritable = false;
   }
   if (!resolvedAccounts.ataProgram.value) {
     resolvedAccounts.ataProgram.value = context.programs.getPublicKey(

--- a/clients/js/src/hooked/AssociatedToken.ts
+++ b/clients/js/src/hooked/AssociatedToken.ts
@@ -8,14 +8,17 @@ export function findAssociatedTokenPda(
     mint: PublicKey;
     /** The owner of the token account */
     owner: PublicKey;
+    /** The Token or Token2022 Program id */
+    tokenProgramId?: PublicKey;
   }
 ): Pda {
   const associatedTokenProgramId =
     context.programs.getPublicKey('splAssociatedToken');
-  const tokenProgramId = context.programs.getPublicKey('splToken');
+  const tokenProgramIdResolved =
+    seeds.tokenProgramId ?? context.programs.getPublicKey('splToken');
   return context.eddsa.findPda(associatedTokenProgramId, [
     publicKey().serialize(seeds.owner),
-    publicKey().serialize(tokenProgramId),
+    publicKey().serialize(tokenProgramIdResolved),
     publicKey().serialize(seeds.mint),
   ]);
 }

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -63,7 +63,11 @@ kinobi.update(
 // Update instructions.
 const ataPdaDefaults = k.pdaDefault("AssociatedToken", {
   importFrom: "hooked",
-  seeds: { owner: k.accountDefault("owner"), mint: k.accountDefault("mint") },
+  seeds: {
+    owner: k.accountDefault("owner"),
+    mint: k.accountDefault("mint"),
+    tokenProgramId: k.accountDefault("tokenProgram")
+  },
 });
 kinobi.update(
   new k.UpdateInstructionsVisitor({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1857,6 +1857,7 @@ packages:
   /node-gyp-build@4.5.0:
     resolution: {integrity: sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==}
     hasBin: true
+    requiresBuild: true
     dev: true
 
   /npm-run-path@4.0.1:


### PR DESCRIPTION
# Description:
`findAssociatedTokenPda()` is updated. Now it accepts another seed - `tokenProgramId`. It’s a specific public key for either Token or Token2022 Program as we discussed with @blockiosaurus. Tests are updated accordingly.

NB! JS tests will fail because `findAssociatedTokenPda()` is used in generated by Kinobi instructions. Specifically:
src/generated/instructions/createAssociatedToken.ts
src/generated/instructions/createTokenIfMissing.ts

And generated files shouldn’t be changed manually.

BREAKING CHANGE: the `tokenProgramId` param for the `findAssociatedTokenPda()` function breaks js tests which use instructions generated by Kinobi. It will also break any code relying on this function.