### PR TITLE
Add instruction discriminators to associated token instructions

### DIFF
--- a/clients/js/src/generated/instructions/createIdempotentAssociatedToken.ts
+++ b/clients/js/src/generated/instructions/createIdempotentAssociatedToken.ts
@@ -15,6 +15,12 @@ import {
   transactionBuilder,
 } from '@metaplex-foundation/umi';
 import {
+  Serializer,
+  mapSerializer,
+  struct,
+  u8,
+} from '@metaplex-foundation/umi/serializers';
+import {
   ResolvedAccount,
   ResolvedAccountsWithIndices,
   getAccountMetasAndSigners,
@@ -29,6 +35,33 @@ export type CreateIdempotentAssociatedTokenInstructionAccounts = {
   systemProgram?: PublicKey | Pda;
   tokenProgram?: PublicKey | Pda;
 };
+
+// Data.
+export type CreateIdempotentAssociatedTokenInstructionData = {
+  discriminator: number;
+};
+
+export type CreateIdempotentAssociatedTokenInstructionDataArgs = {};
+
+export function getCreateIdempotentAssociatedTokenInstructionDataSerializer(): Serializer<
+  CreateIdempotentAssociatedTokenInstructionDataArgs,
+  CreateIdempotentAssociatedTokenInstructionData
+> {
+  return mapSerializer<
+    CreateIdempotentAssociatedTokenInstructionDataArgs,
+    any,
+    CreateIdempotentAssociatedTokenInstructionData
+  >(
+    struct<CreateIdempotentAssociatedTokenInstructionData>(
+      [['discriminator', u8()]],
+      { description: 'CreateIdempotentAssociatedTokenInstructionData' }
+    ),
+    (value) => ({ ...value, discriminator: 1 })
+  ) as Serializer<
+    CreateIdempotentAssociatedTokenInstructionDataArgs,
+    CreateIdempotentAssociatedTokenInstructionData
+  >;
+}
 
 // Instruction.
 export function createIdempotentAssociatedToken(
@@ -91,7 +124,8 @@ export function createIdempotentAssociatedToken(
   );
 
   // Data.
-  const data = new Uint8Array();
+  const data =
+    getCreateIdempotentAssociatedTokenInstructionDataSerializer().serialize({});
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/clients/js/src/generated/instructions/recoverNestedAssociatedToken.ts
+++ b/clients/js/src/generated/instructions/recoverNestedAssociatedToken.ts
@@ -15,6 +15,12 @@ import {
   transactionBuilder,
 } from '@metaplex-foundation/umi';
 import {
+  Serializer,
+  mapSerializer,
+  struct,
+  u8,
+} from '@metaplex-foundation/umi/serializers';
+import {
   ResolvedAccount,
   ResolvedAccountsWithIndices,
   getAccountMetasAndSigners,
@@ -30,6 +36,33 @@ export type RecoverNestedAssociatedTokenInstructionAccounts = {
   walletAddress: Signer;
   tokenProgram?: PublicKey | Pda;
 };
+
+// Data.
+export type RecoverNestedAssociatedTokenInstructionData = {
+  discriminator: number;
+};
+
+export type RecoverNestedAssociatedTokenInstructionDataArgs = {};
+
+export function getRecoverNestedAssociatedTokenInstructionDataSerializer(): Serializer<
+  RecoverNestedAssociatedTokenInstructionDataArgs,
+  RecoverNestedAssociatedTokenInstructionData
+> {
+  return mapSerializer<
+    RecoverNestedAssociatedTokenInstructionDataArgs,
+    any,
+    RecoverNestedAssociatedTokenInstructionData
+  >(
+    struct<RecoverNestedAssociatedTokenInstructionData>(
+      [['discriminator', u8()]],
+      { description: 'RecoverNestedAssociatedTokenInstructionData' }
+    ),
+    (value) => ({ ...value, discriminator: 2 })
+  ) as Serializer<
+    RecoverNestedAssociatedTokenInstructionDataArgs,
+    RecoverNestedAssociatedTokenInstructionData
+  >;
+}
 
 // Instruction.
 export function recoverNestedAssociatedToken(
@@ -103,7 +136,8 @@ export function recoverNestedAssociatedToken(
   );
 
   // Data.
-  const data = new Uint8Array();
+  const data =
+    getRecoverNestedAssociatedTokenInstructionDataSerializer().serialize({});
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/clients/js/test/createIdempotentAssociatedToken.test.ts
+++ b/clients/js/test/createIdempotentAssociatedToken.test.ts
@@ -1,0 +1,81 @@
+import { generateSigner, none } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  createIdempotentAssociatedToken,
+  createMint,
+  fetchToken,
+  findAssociatedTokenPda,
+  getTokenSize,
+  Token,
+  TokenState,
+} from '../src';
+import { createUmi } from './_setup';
+
+test('it can create a new associated token account', async (t) => {
+  // Given an existing mint.
+  const umi = await createUmi();
+  const newMint = generateSigner(umi);
+  await createMint(umi, { mint: newMint }).sendAndConfirm(umi);
+  const [ata] = findAssociatedTokenPda(umi, {
+    mint: newMint.publicKey,
+    owner: umi.identity.publicKey,
+  });
+
+  // When we create its associated token account idempotently.
+  await createIdempotentAssociatedToken(umi, {
+    mint: newMint.publicKey,
+    owner: umi.identity.publicKey,
+    ata,
+  }).sendAndConfirm(umi);
+
+  // Then the account was created with the correct data
+  // And the token account is associated to the identity.
+  const tokenAccount = await fetchToken(umi, ata);
+  t.like(tokenAccount, <Token>{
+    publicKey: ata,
+    header: {
+      owner: umi.programs.get('splToken').publicKey,
+      lamports: await umi.rpc.getRent(getTokenSize()),
+      executable: false,
+    },
+    mint: newMint.publicKey,
+    owner: umi.identity.publicKey,
+    amount: 0n,
+    delegate: none(),
+    state: TokenState.Initialized,
+    isNative: none(),
+    delegatedAmount: 0n,
+    closeAuthority: none(),
+  });
+});
+
+test('it does not fail when the associated token account already exists', async (t) => {
+  // Given an existing mint and an already-created associated token account.
+  const umi = await createUmi();
+  const newMint = generateSigner(umi);
+  await createMint(umi, { mint: newMint }).sendAndConfirm(umi);
+  const [ata] = findAssociatedTokenPda(umi, {
+    mint: newMint.publicKey,
+    owner: umi.identity.publicKey,
+  });
+  await createIdempotentAssociatedToken(umi, {
+    mint: newMint.publicKey,
+    owner: umi.identity.publicKey,
+    ata,
+  }).sendAndConfirm(umi);
+
+  // When we create it again idempotently.
+  // Then the instruction does not throw, unlike the non-idempotent variant.
+  await t.notThrowsAsync(
+    createIdempotentAssociatedToken(umi, {
+      mint: newMint.publicKey,
+      owner: umi.identity.publicKey,
+      ata,
+    }).sendAndConfirm(umi)
+  );
+
+  // And the token account still exists and is unchanged.
+  const tokenAccount = await fetchToken(umi, ata);
+  t.is(tokenAccount.mint, newMint.publicKey);
+  t.is(tokenAccount.owner, umi.identity.publicKey);
+});

--- a/idls/spl_associated_token.json
+++ b/idls/spl_associated_token.json
@@ -72,7 +72,11 @@
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 1
+      }
     },
     {
       "name": "recoverNestedAssociatedToken",
@@ -113,7 +117,11 @@
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 2
+      }
     }
   ],
   "errors": [


### PR DESCRIPTION
## Summary
This PR adds explicit instruction discriminators to the `createIdempotentAssociatedToken` and `recoverNestedAssociatedToken` instructions, replacing empty data serialization with proper discriminator-based encoding.

## Key Changes
- **Added discriminator types and serializers**: Introduced `InstructionData` and `InstructionDataArgs` types for both instructions with corresponding serializer functions
  - `createIdempotentAssociatedToken` uses discriminator value `1`
  - `recoverNestedAssociatedToken` uses discriminator value `2`
- **Updated instruction data serialization**: Changed from empty `Uint8Array()` to using the new serializer functions that properly encode the discriminator byte
- **Updated IDL**: Added explicit `discriminant` field to both instruction definitions in the IDL JSON, specifying the u8 type and corresponding values

## Implementation Details
- The serializers use `mapSerializer` to automatically inject the discriminator value during serialization
- Both instructions follow the same pattern with a single u8 discriminator field
- The serializer functions accept empty argument objects (`{}`) since these instructions have no additional data parameters
- This change ensures proper instruction identification on-chain and maintains compatibility with the Metaplex UMI framework

https://claude.ai/code/session_011bEnmh3Yarza6aMGUJwrXX